### PR TITLE
preallocate struct deserialization with table.clone

### DIFF
--- a/src/main.luau
+++ b/src/main.luau
@@ -842,7 +842,8 @@ function ByteWorks.optStruct(fields: {[string]: ByteWorksType<any>}): ByteWorksT
 		end,
 
 		des = function(buff, offset: number)
-			local elements = {}
+			-- perf; cloning the fields preallocates indices, significantly improving deserialization times.
+			local elements = table.clone(fields)
 
 			local bitmap = 0
 			for i = optionalBytes, 1, -1 do


### PR DESCRIPTION
When deserializing a struct or optStruct, table.clone the template before filling any of the fields, so they're all pre-allocated. Appropriate comments have been left. On my projects, as well as on blink, and on ByteNet, I observed this to be a 5-10x optimization to struct deserialization.